### PR TITLE
replace macOS-10.14 with macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macOS-10.14, windows-2019]
+        os: [ubuntu-18.04, macos-latest, windows-2019]
         python: [3.6, 3.7, 3.8]
         exclude:
            # As of 10/30/19, the macOS environment does not have Python 3.8
-          - os: macOS-10.14
+          - os: macos-latest
             python: 3.8
             # As of 10/30/19, the Windows environment does not have Python 3.8
           - os: windows-2019


### PR DESCRIPTION
GitHub sent an email to notify me that macOS 10.14 support is going away.  It is being replaced with macOS 10.15.  The guidance is to use the `macos-latest` environment.